### PR TITLE
Fix getCurrentUser principal

### DIFF
--- a/src/main/java/com/dataloom/authorization/Principals.java
+++ b/src/main/java/com/dataloom/authorization/Principals.java
@@ -30,7 +30,7 @@ public final class Principals {
         return new Principal(
                 PrincipalType.USER,
                 ( (Auth0UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal() )
-                        .getUsername() );
+                        .getAuth0Attribute("user_id").toString() );
     }
 
     public static Set<Principal> getCurrentPrincipals() {


### PR DESCRIPTION
getCurrentUser creates the Principal from the Auth0 user_id instead of the username