### PR TITLE
bugfix increment order

### DIFF
--- a/src/main/java/com/dataloom/directory/UserDirectoryService.java
+++ b/src/main/java/com/dataloom/directory/UserDirectoryService.java
@@ -63,7 +63,7 @@ public class UserDirectoryService {
         Set<Auth0UserBasic> users = Sets.newHashSet();
         for ( Set<Auth0UserBasic> pageOfUsers = auth0ManagementApi.getAllUsers( page, 100 );
               users.isEmpty() || pageOfUsers.size() == 100; pageOfUsers = auth0ManagementApi
-                .getAllUsers( page++, 100 ) ) {
+                .getAllUsers( ++page, 100 ) ) {
             users.addAll( pageOfUsers );
         }
 


### PR DESCRIPTION
We are making a duplicate call for page 0. This causes error when collecting to a map due to duplicate keys:
https://github.com/dataloom/conductor-client/blob/e11942ec802af026d5e299e1247736d4bd6874f1/src/main/java/com/dataloom/directory/UserDirectoryService.java#L77

Alternatively (and we probably want to do this), add hash function to `Auth0UserBasic` to avoid duplicates in the first place:
https://github.com/dataloom/loom-api/pull/92