### PR TITLE
don't register TreeSetCodec

### DIFF
--- a/src/main/java/com/kryptnostic/conductor/codecs/pods/TypeCodecsPod.java
+++ b/src/main/java/com/kryptnostic/conductor/codecs/pods/TypeCodecsPod.java
@@ -128,10 +128,5 @@ public class TypeCodecsPod {
     public TypeCodec<EntityKey> entitykeyCodec() {
         return new EntityKeyTypeCodec( ObjectMappers.getJsonMapper() );
     }
-    
-    @Bean
-    public TypeCodec<Set<UUID>> uuidTreeSetCodec(){
-        return TreeSetCodec.getUUIDInstance();
-    }
 
 }


### PR DESCRIPTION
Sometimes Set<UUID> in Cassandra gets deserialized to TreeSet instead of LinkedHashSet, causing casting problems in Row Adapters