### PR TITLE
Streamline authorization checks.

### DIFF
--- a/src/main/java/com/dataloom/authorization/AuthorizationManager.java
+++ b/src/main/java/com/dataloom/authorization/AuthorizationManager.java
@@ -21,8 +21,11 @@ package com.dataloom.authorization;
 
 import com.dataloom.authorization.paging.AuthorizedObjectsSearchResult;
 import com.dataloom.authorization.securable.SecurableObjectType;
+import com.openlattice.authorization.AceValue;
 import com.openlattice.authorization.AclKey;
+import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -68,6 +71,10 @@ public interface AuthorizationManager {
 
     void deletePrincipalPermissions( Principal principal );
 
+    Map<AclKey, EnumMap<Permission, Boolean>> accessChecksForPrincipals(
+            Set<AccessCheck> accessChecks,
+            Set<Principal> principals );
+
     boolean checkIfHasPermissions(
             AclKey aclKeys,
             Set<Principal> principals,
@@ -104,4 +111,6 @@ public interface AuthorizationManager {
     Stream<AclKey> getAuthorizedObjects( Set<Principal> principal, EnumSet<Permission> permissions );
 
     Iterable<Principal> getSecurableObjectOwners( AclKey key );
+
+    Map<AceKey, AceValue> getPermissionMap( Set<AclKey> aclKeys, Set<Principal> principals );
 }

--- a/src/main/java/com/dataloom/hazelcast/StreamSerializerTypeIds.java
+++ b/src/main/java/com/dataloom/hazelcast/StreamSerializerTypeIds.java
@@ -34,6 +34,7 @@ public enum StreamSerializerTypeIds {
     ACL_KEY,
     ACL_KEY_SET,
     AUDIT_METRIC_INCREMENTER,
+    AUTHORIZATION_AGGREGATOR,
     BYTE_BUFFER,
     RUNNABLE,
     CALLABLE,

--- a/src/main/java/com/dataloom/hazelcast/serializers/AuthorizationAggregatorStreamSerializer.java
+++ b/src/main/java/com/dataloom/hazelcast/serializers/AuthorizationAggregatorStreamSerializer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017. OpenLattice, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@openlattice.com
+ *
+ */
+
+package com.dataloom.hazelcast.serializers;
+
+import com.codahale.metrics.annotation.Timed;
+import com.dataloom.authorization.Permission;
+import com.dataloom.hazelcast.StreamSerializerTypeIds;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.kryptnostic.rhizome.pods.hazelcast.SelfRegisteringStreamSerializer;
+import com.openlattice.authorization.AuthorizationAggregator;
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map.Entry;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+@Component
+public class AuthorizationAggregatorStreamSerializer
+        implements SelfRegisteringStreamSerializer<AuthorizationAggregator> {
+    @Override public Class<AuthorizationAggregator> getClazz() {
+        return AuthorizationAggregator.class;
+    }
+
+    @Timed
+    @Override
+    public void write(
+            ObjectDataOutput out, AuthorizationAggregator object ) throws IOException {
+        //TODO: We can improve performance of this.
+        PermissionMergerStreamSerializer
+                .serialize( out, object.getPermissions().entrySet().stream().filter( e -> e.getValue() ).map(
+                        Entry::getKey )::iterator );
+        PermissionMergerStreamSerializer
+                .serialize( out, object.getPermissions().entrySet().stream().filter( e -> !e.getValue() ).map(
+                        Entry::getKey )::iterator );
+
+    }
+
+    @Override public AuthorizationAggregator read( ObjectDataInput in ) throws IOException {
+        EnumMap<Permission, Boolean> pMap = new EnumMap<>( Permission.class );
+        EnumSet<Permission> truePermissions = PermissionMergerStreamSerializer.deserialize( in );
+        EnumSet<Permission> falsePermissions = PermissionMergerStreamSerializer.deserialize( in );
+        for ( Permission p : truePermissions ) {
+            pMap.put( p, true );
+        }
+
+        for ( Permission p : falsePermissions ) {
+            pMap.put( p, false );
+        }
+
+        return new AuthorizationAggregator( pMap );
+    }
+
+    @Override public int getTypeId() {
+        return StreamSerializerTypeIds.AUTHORIZATION_AGGREGATOR.ordinal();
+    }
+
+    @Override public void destroy() {
+
+    }
+}

--- a/src/main/java/com/dataloom/hazelcast/serializers/PermissionMergerStreamSerializer.java
+++ b/src/main/java/com/dataloom/hazelcast/serializers/PermissionMergerStreamSerializer.java
@@ -44,24 +44,12 @@ public class PermissionMergerStreamSerializer implements SelfRegisteringStreamSe
 
     @Override public void write(
             ObjectDataOutput out, PermissionMerger object ) throws IOException {
-        BitSet bs = new BitSet( P.length );
-        for ( Permission p : object.getBackingCollection() ) {
-            bs.set( p.ordinal() );
-        }
-        out.writeLongArray( bs.toLongArray() );
-        //TODO: Move this method to class where it's not as hidden
+        serialize( out, object.getBackingCollection() );
         AceValueStreamSerializer.serialize( out, object.getSecurableObjectType() );
     }
 
     @Override public PermissionMerger read( ObjectDataInput in ) throws IOException {
-        BitSet bs = BitSet.valueOf( in.readLongArray() );
-
-        EnumSet<Permission> ps = EnumSet.noneOf( Permission.class );
-        for ( int i = 0; i < P.length; ++i ) {
-            if ( bs.get( i ) ) {
-                ps.add( P[ i ] );
-            }
-        }
+        EnumSet<Permission> ps = deserialize( in );
         SecurableObjectType securableObjectType = AceValueStreamSerializer.deserialize( in );
         return new PermissionMerger( ps, securableObjectType );
     }
@@ -71,6 +59,28 @@ public class PermissionMergerStreamSerializer implements SelfRegisteringStreamSe
     }
 
     @Override public void destroy() {
+
+    }
+
+    public static EnumSet<Permission> deserialize( ObjectDataInput in ) throws IOException {
+        BitSet bs = BitSet.valueOf( in.readLongArray() );
+
+        EnumSet<Permission> ps = EnumSet.noneOf( Permission.class );
+        for ( int i = 0; i < P.length; ++i ) {
+            if ( bs.get( i ) ) {
+                ps.add( P[ i ] );
+            }
+        }
+        return ps;
+    }
+
+    public static void serialize( ObjectDataOutput out, Iterable<Permission> object ) throws IOException {
+        BitSet bs = new BitSet( P.length );
+        for ( Permission p : object ) {
+            bs.set( p.ordinal() );
+        }
+        out.writeLongArray( bs.toLongArray() );
+        //TODO: Move this method to class where it's not as hidden
 
     }
 }

--- a/src/main/java/com/kryptnostic/datastore/services/EdmService.java
+++ b/src/main/java/com/kryptnostic/datastore/services/EdmService.java
@@ -373,11 +373,12 @@ public class EdmService implements EdmManager {
         try {
             setupDefaultEntitySetPropertyMetadata( entitySet.getId(), entitySet.getEntityTypeId() );
 
+            authorizations.setSecurableObjectType( new AclKey( entitySet.getId() ), SecurableObjectType.EntitySet );
+
             authorizations.addPermission( new AclKey( entitySet.getId() ),
                     principal,
                     EnumSet.allOf( Permission.class ) );
 
-            authorizations.setSecurableObjectType( new AclKey( entitySet.getId() ), SecurableObjectType.EntitySet );
 
             ownablePropertyTypes.stream()
                     .map( propertyTypeId -> new AclKey( entitySet.getId(), propertyTypeId ) )
@@ -388,12 +389,7 @@ public class EdmService implements EdmManager {
                     .forEach( aclKey -> {
                         authorizations.setSecurableObjectType( aclKey,
                                 SecurableObjectType.PropertyTypeInEntitySet );
-                        securableObjectTypes.set( aclKey,
-                                SecurableObjectType.PropertyTypeInEntitySet );
                     } );
-
-            securableObjectTypes.set( new AclKey( entitySet.getId() ),
-                    SecurableObjectType.EntitySet );
 
             eventBus.post( new EntitySetCreatedEvent(
                     entitySet,
@@ -638,12 +634,13 @@ public class EdmService implements EdmManager {
                     propertyTypeIds.stream()
                             .map( propertyTypeId -> new AclKey( entitySet.getId(), propertyTypeId ) )
                             .forEach( aclKey -> {
+                                authorizations.setSecurableObjectType( aclKey,
+                                        SecurableObjectType.PropertyTypeInEntitySet );
+
                                 authorizations.addPermission(
                                         aclKey,
                                         owner,
                                         EnumSet.allOf( Permission.class ) );
-                                authorizations.setSecurableObjectType( aclKey,
-                                        SecurableObjectType.PropertyTypeInEntitySet );
 
                                 PropertyType pt = propertyTypes.get( aclKey.get( 1 ) );
                                 EntitySetPropertyMetadata defaultMetadata = new EntitySetPropertyMetadata(

--- a/src/main/java/com/openlattice/authorization/AuthorizationAggregator.java
+++ b/src/main/java/com/openlattice/authorization/AuthorizationAggregator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2017. OpenLattice, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@openlattice.com
+ *
+ */
+
+package com.openlattice.authorization;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.dataloom.authorization.AceKey;
+import com.dataloom.authorization.Permission;
+import com.hazelcast.aggregation.Aggregator;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+public class AuthorizationAggregator extends Aggregator<Entry<AceKey, AceValue>, AuthorizationAggregator> {
+    private static final Logger logger = LoggerFactory.getLogger( AuthorizationAggregator.class );
+    private final EnumMap<Permission, Boolean> permissions;
+
+    public AuthorizationAggregator( Set<Permission> requestedPermissions ) {
+        this.permissions = new EnumMap<>( Permission.class );
+        requestedPermissions.forEach( ac -> permissions.put( ac, false ) );
+    }
+
+    public AuthorizationAggregator( EnumMap<Permission, Boolean> permissions ) {
+        this.permissions = permissions;
+    }
+
+    @Override public void accumulate( Entry<AceKey, AceValue> input ) {
+        final EnumSet<Permission> acePermissions = checkNotNull(
+                input.getValue().getPermissions(),
+                "Permissions shouldn't be null" );
+
+        for ( Permission p : acePermissions ) {
+            permissions.computeIfPresent( p, ( k, v ) -> acePermissions.contains( p ) || v.booleanValue() );
+        }
+
+    }
+
+    @Override public void combine( Aggregator aggregator ) {
+        //A class cast exception = madness
+        AuthorizationAggregator other = (AuthorizationAggregator) aggregator;
+        //They should be the same keysets
+        for ( Entry<Permission, Boolean> e : other.permissions.entrySet() ) {
+            Permission p = e.getKey();
+            permissions.put( p, permissions.get( p ).booleanValue() || e.getValue().booleanValue() );
+        }
+    }
+
+    public EnumMap<Permission, Boolean> getPermissions() {
+        return permissions;
+    }
+
+    @Override public AuthorizationAggregator aggregate() {
+        return this;
+    }
+
+    @Override public boolean equals( Object o ) {
+        if ( this == o ) { return true; }
+        if ( !( o instanceof AuthorizationAggregator ) ) { return false; }
+
+        AuthorizationAggregator that = (AuthorizationAggregator) o;
+
+        return permissions.equals( that.permissions );
+    }
+
+    @Override public int hashCode() {
+        return permissions.hashCode();
+    }
+
+}

--- a/src/main/java/com/openlattice/postgres/mapstores/EdmVersionsMapstore.java
+++ b/src/main/java/com/openlattice/postgres/mapstores/EdmVersionsMapstore.java
@@ -1,12 +1,15 @@
 package com.openlattice.postgres.mapstores;
 
+import static com.openlattice.postgres.PostgresColumn.EDM_VERSION;
+import static com.openlattice.postgres.PostgresColumn.EDM_VERSION_NAME;
+import static com.openlattice.postgres.PostgresTable.EDM_VERSIONS;
+
 import com.auth0.jwt.internal.org.apache.commons.lang3.RandomStringUtils;
 import com.dataloom.hazelcast.HazelcastMap;
 import com.google.common.collect.ImmutableList;
 import com.openlattice.postgres.PostgresColumnDefinition;
 import com.openlattice.postgres.ResultSetAdapters;
 import com.zaxxer.hikari.HikariDataSource;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -15,22 +18,22 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.openlattice.postgres.PostgresColumn.EDM_VERSION;
-import static com.openlattice.postgres.PostgresColumn.EDM_VERSION_NAME;
-import static com.openlattice.postgres.PostgresTable.EDM_VERSIONS;
-
 public class EdmVersionsMapstore extends AbstractBasePostgresMapstore<String, UUID> {
     private final HikariDataSource hds;
-    private final String           loadQuerySql;
-    private final String           insertQuerySql;
 
     public EdmVersionsMapstore( HikariDataSource hds ) {
         super( HazelcastMap.EDM_VERSIONS.name(), EDM_VERSIONS, hds );
         this.hds = hds;
-        this.loadQuerySql = "SELECT * FROM ".concat( EDM_VERSIONS.getName() ).concat( " WHERE " )
+    }
+
+    @Override protected String buildSelectByKeyQuery() {
+        return "SELECT * FROM ".concat( EDM_VERSIONS.getName() ).concat( " WHERE " )
                 .concat( EDM_VERSION_NAME.getName() ).concat( " = ? ORDER BY " ).concat( EDM_VERSION.getName() )
                 .concat( " DESC LIMIT 1;" );
-        this.insertQuerySql = EDM_VERSIONS.insertQuery( Optional.empty(), ImmutableList.of() );
+    }
+
+    @Override protected String buildInsertQuery() {
+        return EDM_VERSIONS.insertQuery( Optional.empty(), ImmutableList.of() );
     }
 
     @Override protected List<PostgresColumnDefinition> keyColumns() {
@@ -56,37 +59,6 @@ public class EdmVersionsMapstore extends AbstractBasePostgresMapstore<String, UU
 
     @Override protected String mapToKey( ResultSet rs ) throws SQLException {
         return ResultSetAdapters.edmVersionName( rs );
-    }
-
-    @Override
-    public UUID load( String key ) {
-        UUID val = null;
-        try ( Connection connection = hds.getConnection();
-                PreparedStatement selectRow = connection.prepareStatement( loadQuerySql ); ) {
-            bind( selectRow, key );
-            ResultSet rs = selectRow.executeQuery();
-            if ( rs.next() ) {
-                val = mapToValue( rs );
-            }
-            rs.close();
-            connection.close();
-        } catch ( SQLException e ) {
-            logger.error( "Error executing SQL during select for key {}.", key, e );
-        }
-        return val;
-    }
-
-    @Override
-    public void store( String key, UUID value ) {
-        try ( Connection connection = hds.getConnection();
-                PreparedStatement insertRow = connection.prepareStatement( insertQuerySql ) ) {
-            bind( insertRow, key, value );
-            logger.info( insertRow.toString() );
-            insertRow.execute();
-            connection.close();
-        } catch ( SQLException e ) {
-            logger.error( "Error executing SQL during store for key {}.", key, e );
-        }
     }
 
     @Override public String generateTestKey() {

--- a/src/main/java/com/openlattice/postgres/mapstores/SecurableObjectTypeMapstore.java
+++ b/src/main/java/com/openlattice/postgres/mapstores/SecurableObjectTypeMapstore.java
@@ -40,7 +40,7 @@ public class SecurableObjectTypeMapstore extends AbstractBasePostgresMapstore<Ac
     }
 
     @Override protected void bind( PreparedStatement ps, AclKey key ) throws SQLException {
-        ps.setArray( 1, PostgresArrays.createUuidArray( ps.getConnection(), key.stream() ) );
+        ps.setArray( 1, PostgresArrays.createUuidArray( ps.getConnection(), key ) );
     }
 
     @Override protected SecurableObjectType mapToValue( ResultSet rs ) throws SQLException {

--- a/src/test/java/com/dataloom/hazelcast/serializers/AuthorizationAggregatorStreamSerializerTest.java
+++ b/src/test/java/com/dataloom/hazelcast/serializers/AuthorizationAggregatorStreamSerializerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017. OpenLattice, Inc
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@openlattice.com
+ *
+ */
+
+package com.dataloom.hazelcast.serializers;
+
+import com.dataloom.authorization.Permission;
+import com.kryptnostic.rhizome.hazelcast.serializers.AbstractStreamSerializerTest;
+import com.openlattice.authorization.AuthorizationAggregator;
+import java.util.EnumMap;
+
+/**
+ * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
+ */
+public class AuthorizationAggregatorStreamSerializerTest extends AbstractStreamSerializerTest<AuthorizationAggregatorStreamSerializer,AuthorizationAggregator> {
+
+    @Override protected AuthorizationAggregatorStreamSerializer createSerializer() {
+        return new AuthorizationAggregatorStreamSerializer();
+    }
+
+    @Override protected AuthorizationAggregator createInput() {
+        EnumMap<Permission, Boolean> pmap = new EnumMap<> (Permission.class);
+        pmap.put( Permission.OWNER, true );
+        pmap.put( Permission.LINK, true );
+        pmap.put( Permission.READ, false );
+        pmap.put( Permission.WRITE, true );
+        pmap.put( Permission.DISCOVER, false );
+        return new AuthorizationAggregator( pmap );
+    }
+}

--- a/src/test/resources/auth0.yaml
+++ b/src/test/resources/auth0.yaml
@@ -1,0 +1,9 @@
+domain: "openlattice.auth0.com"
+issuer: "https://openlattice.auth0.com/"
+clientId: "KTzgyxs6KBcJHB872eSMe2cpTHzhxS99"
+clientSecret: "tjAwhBit0deVUor3lcd7YRlHRc_4FJwv_fcLp_ozO2-D2Lh38066IUoGPL4zx1vP"
+securedRoute: "NOT_USED"
+authorityStrategy: "ROLES"
+signingAlgorithm: "HS256"
+base64EncodedSecret: false
+token: "lol"


### PR DESCRIPTION
- Authorization checks now use fast aggregators to minimize serialization and contention.
- Added tests for AuthzAggregator stream serializer
- Removed Cassandra from starting up during tests.
- Updated EdmVerionsMapstore so it doesn't unnecessarily override base methods
- Added tests for access check methods.